### PR TITLE
Add backwards compat for python < 3.9

### DIFF
--- a/Generator/GenerateHtmlCMake.py
+++ b/Generator/GenerateHtmlCMake.py
@@ -26,20 +26,23 @@ def GenerateExample(example_name, source_path, dest_path, vtk_source_path):
         data = cmake.read()
     data = data.replace('XXX', example_name)
     try:
-        process = subprocess.run('python3 WhatModulesVTK.py ' + vtk_source_path + ' ' + source_path, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        process = subprocess.run('python3 WhatModulesVTK.py ' + vtk_source_path + ' ' + source_path, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        result = process.stdout.decode('utf-8')
     except subprocess.CalledProcessError as err:
         print('ERROR:', err)
-        if process.returncode != 0:
-            print('returncode:', process.returncode)
+        if err.returncode != 0:
+            print('returncode:', err.returncode)
             print('Have {} bytes in stdout:\n{}'.format(
-                len(process.stdout),
-                process.stdout.decode('utf-8'))
-                    )
+                    len(err.stdout),
+                    err.stdout.decode('utf-8'))
+                        )
             print('Have {} bytes in stderr:\n{}'.format(
-                len(process.stderr),
-                process.stderr.decode('utf-8'))
-                    )
-    result = process.stdout.decode('utf-8')
+                    len(err.stderr),
+                    err.stderr.decode('utf-8'))
+                        )
+        result = f"# The following error occurred running {err.cmd}\n"
+        for line in err.stderr.decode('utf-8').split('\n'):
+            result += f"# {line}\n"
     data = data.replace('ZZZ', result)
     with open(os.path.join(dest_path, 'CMakeLists.txt'), 'w') as cmake:
         cmake.write(data)
@@ -67,19 +70,22 @@ def GenerateExampleArgs(example_name, source_path, dest_path, vtk_source_path, a
     data = data.replace('XXX', example_name)
     try:
         process = subprocess.run('python3 WhatModulesVTK.py ' + vtk_source_path + ' ' + source_path, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        result = process.stdout.decode('utf-8')
     except subprocess.CalledProcessError as err:
         print('ERROR:', err)
-        if process.returncode != 0:
-            print('returncode:', process.returncode)
+        if err.returncode != 0:
+            print('returncode:', err.returncode)
             print('Have {} bytes in stdout:\n{}'.format(
-                    len(process.stdout),
-                    process.stdout.decode('utf-8'))
+                    len(err.stdout),
+                    err.stdout.decode('utf-8'))
                         )
             print('Have {} bytes in stderr:\n{}'.format(
-                    len(process.stderr),
-                    process.stderr.decode('utf-8'))
+                    len(err.stderr),
+                    err.stderr.decode('utf-8'))
                         )
-    result = process.stdout.decode('utf-8')
+        result = f"# The following error occurred running {err.cmd}\n"
+        for line in err.stderr.decode('utf-8').split('\n'):
+            result += f"# {line}\n"
     data = data.replace('ZZZ', result)
     # for filename in args_data.get('files'):
         # try:

--- a/Generator/WhatModulesVTK.py
+++ b/Generator/WhatModulesVTK.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python
 
 import re
+import sys
 from collections import defaultdict
 from pathlib import Path
 
+def remove_prefix(text, prefix):
+    if sys.version_info > (3, 9):
+        return text.removeprefix(prefix)
+    else:
+        if text.startswith(prefix): # only modify the text if it starts with the prefix
+            text = text.replace(prefix, "", 1) # remove one instance of prefix
+        return text
 
 def get_program_parameters():
     import argparse
@@ -184,7 +192,7 @@ def generate_find_package(vtk_src_dir, application_srcs):
 
     res = ['find_package(VTK', ' COMPONENTS']
     for m in sorted(all_modules):
-        m = m.removeprefix('VTK::')
+        m = remove_prefix(m, 'VTK::')
         res.append(' ' * 2 + m)
     res.append('REQUIRED)')
     return res


### PR DESCRIPTION
- `removeprefix` is available only in python 3.9+
- make subprocess error visible by writing out error as a comment in the `CMakeLists.txt`